### PR TITLE
Fix the login URL

### DIFF
--- a/delete.py
+++ b/delete.py
@@ -98,7 +98,7 @@ def login(creds):
     brows.set_page_load_timeout(20)
 
     brows.get(
-        f'https://twitter.com/i/flow/login?redirect_after_login=%2F{creds["username"]}'
+        f'https://x.com/i/flow/login'
     )
 
     username = WebDriverWait(brows, 20).until(


### PR DESCRIPTION
The URL that was loaded was a twitter.com URL, which resulted in a redirect, breaking the login flow. This changes it to a URL that works for logging in.
